### PR TITLE
Add zebra bread to homepage menu

### DIFF
--- a/docs/images/zebra_bread.svg
+++ b/docs/images/zebra_bread.svg
@@ -1,0 +1,12 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200">
+  <rect width="200" height="200" fill="none"/>
+  <rect x="30" y="60" width="140" height="90" rx="20" ry="20" fill="#ffe5b4"/>
+  <polygon points="60,60 70,40 80,60" fill="#ffe5b4"/>
+  <polygon points="140,60 130,40 120,60" fill="#ffe5b4"/>
+  <path d="M40 60 L80 150" stroke="#5a3e2b" stroke-width="5"/>
+  <path d="M80 60 L120 150" stroke="#5a3e2b" stroke-width="5"/>
+  <path d="M120 60 L160 150" stroke="#5a3e2b" stroke-width="5"/>
+  <circle cx="85" cy="100" r="5" fill="#5a3e2b"/>
+  <circle cx="115" cy="100" r="5" fill="#5a3e2b"/>
+  <circle cx="100" cy="115" r="7" fill="#5a3e2b"/>
+</svg>

--- a/docs/index.html
+++ b/docs/index.html
@@ -58,6 +58,11 @@
       <img src="images/giraffe_bread.svg" alt="キリンさんパン" width="200" height="200">
       <p>のっぽなキリンさんがモチーフの、サクサク生地が自慢のパン！</p>
     </div>
+    <div class="product">
+      <h3>しまうまパン</h3>
+      <img src="images/zebra_bread.svg" alt="しまうまパン" width="200" height="200">
+      <p>しましま模様がおしゃれな、見た目も味も楽しいパン！</p>
+    </div>
   </div>
 </section>
 <footer>


### PR DESCRIPTION
## Summary
- add zebra bread SVG asset
- feature zebra bread in homepage's recommended menu

## Testing
- `npm test` *(fails: missing package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b1ad5653c08331b2c67cfe81db992a