### PR TITLE
Add form validation page with tests

### DIFF
--- a/docs/form.html
+++ b/docs/form.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>入力フォームとJSON変換</title>
+  <link rel="stylesheet" href="styles/form.css">
+</head>
+<body>
+  <main class="container">
+    <h1>入力フォーム</h1>
+    <p>各項目に値を入力して「JSONに変換」ボタンを押してください。</p>
+    <form id="convert-form" novalidate>
+      <div class="field">
+        <label for="name">名前（日本語）</label>
+        <input id="name" name="name" type="text" autocomplete="name" required>
+        <p class="error" data-error-for="name" aria-live="polite"></p>
+      </div>
+      <div class="field">
+        <label for="num">番号（整数）</label>
+        <input id="num" name="num" type="text" inputmode="numeric" pattern="[0-9]+" required>
+        <p class="error" data-error-for="num" aria-live="polite"></p>
+      </div>
+      <div class="field">
+        <label for="date">日付（YYYY-MM-DD）</label>
+        <input id="date" name="date" type="text" placeholder="2024-01-01" required>
+        <p class="error" data-error-for="date" aria-live="polite"></p>
+      </div>
+      <button id="convert" type="submit">JSONに変換</button>
+    </form>
+    <section aria-live="polite" class="result" id="result"></section>
+  </main>
+  <script type="module" src="scripts/form.js"></script>
+</body>
+</html>

--- a/docs/index.html
+++ b/docs/index.html
@@ -44,7 +44,7 @@
 <header>
   <h1>フィンちゃんのパン屋さん</h1>
   <p>ふわふわでやさしい味のパンをどうぞ</p>
-  <nav><a href="profile.html">ふぃんちゃん店長の自己紹介</a><a href="calc.html">単価計算</a><a href="map.html">ルート検索</a></nav>
+  <nav><a href="profile.html">ふぃんちゃん店長の自己紹介</a><a href="calc.html">単価計算</a><a href="map.html">ルート検索</a><a href="form.html">入力フォーム</a></nav>
 </header>
 <section class="hero">
   <img src="images/finn_bakery.svg" alt="フィンちゃんとくまちゃんパン" width="300" height="300">

--- a/docs/scripts/form.js
+++ b/docs/scripts/form.js
@@ -1,0 +1,53 @@
+import { validateForm } from './validation.js';
+
+document.addEventListener('DOMContentLoaded', () => {
+  const form = document.getElementById('convert-form');
+  const result = document.getElementById('result');
+
+  if (!form || !result) {
+    return;
+  }
+
+  form.addEventListener('submit', (event) => {
+    event.preventDefault();
+    const formData = new FormData(form);
+    const values = Object.fromEntries(formData.entries());
+    const validation = validateForm(values);
+
+    clearErrors(form);
+
+    if (!validation.valid) {
+      displayErrors(form, validation.results);
+      result.textContent = '';
+      result.dataset.state = 'error';
+      return;
+    }
+
+    const payload = {
+      name: validation.results.name.value,
+      num: validation.results.num.value,
+      date: validation.results.date.value,
+    };
+
+    result.textContent = JSON.stringify(payload, null, 2);
+    result.dataset.state = 'success';
+  });
+});
+
+function clearErrors(form) {
+  form.querySelectorAll('.error').forEach((element) => {
+    element.textContent = '';
+  });
+}
+
+function displayErrors(form, results) {
+  Object.entries(results).forEach(([key, outcome]) => {
+    if (outcome.valid) {
+      return;
+    }
+    const errorElement = form.querySelector(`.error[data-error-for="${key}"]`);
+    if (errorElement) {
+      errorElement.textContent = outcome.error;
+    }
+  });
+}

--- a/docs/scripts/validation.js
+++ b/docs/scripts/validation.js
@@ -1,0 +1,54 @@
+export function validateName(value) {
+  const trimmed = (value ?? '').trim();
+  if (!trimmed) {
+    return { valid: false, error: '名前を入力してください。' };
+  }
+  if (!/^[\p{Script=Hiragana}\p{Script=Katakana}\p{Script=Han}\p{P}\p{N}\p{Zs}A-Za-z]+$/u.test(trimmed)) {
+    return { valid: false, error: '日本語の文字を中心に入力してください。' };
+  }
+  return { valid: true, value: trimmed };
+}
+
+export function validateNum(value) {
+  const text = (value ?? '').trim();
+  if (!text) {
+    return { valid: false, error: '整数を入力してください。' };
+  }
+  if (!/^[-+]?\d+$/.test(text)) {
+    return { valid: false, error: '整数のみ入力できます。' };
+  }
+  const parsed = Number.parseInt(text, 10);
+  if (!Number.isSafeInteger(parsed)) {
+    return { valid: false, error: '安全な範囲の整数を入力してください。' };
+  }
+  return { valid: true, value: parsed };
+}
+
+export function validateDate(value) {
+  const text = (value ?? '').trim();
+  if (!text) {
+    return { valid: false, error: '日付を入力してください。' };
+  }
+  if (!/^\d{4}-\d{2}-\d{2}$/.test(text)) {
+    return { valid: false, error: 'YYYY-MM-DD形式で入力してください。' };
+  }
+  const [year, month, day] = text.split('-').map((part) => Number.parseInt(part, 10));
+  const date = new Date(Date.UTC(year, month - 1, day));
+  if (date.getUTCFullYear() !== year || date.getUTCMonth() + 1 !== month || date.getUTCDate() !== day) {
+    return { valid: false, error: '存在する日付を入力してください。' };
+  }
+  return { valid: true, value: text };
+}
+
+export function validateForm(values) {
+  const results = {
+    name: validateName(values.name),
+    num: validateNum(values.num),
+    date: validateDate(values.date),
+  };
+  const hasError = Object.values(results).some((result) => !result.valid);
+  return {
+    valid: !hasError,
+    results,
+  };
+}

--- a/docs/styles/form.css
+++ b/docs/styles/form.css
@@ -1,0 +1,87 @@
+:root {
+  color-scheme: light;
+  --primary: #5a3e2b;
+  --accent: #ffe4e1;
+  --error: #d9534f;
+  --background: #fffaf0;
+}
+
+body {
+  font-family: 'Hiragino Sans', 'Yu Gothic', sans-serif;
+  margin: 0;
+  min-height: 100vh;
+  background: linear-gradient(135deg, var(--background) 0%, #fff 100%);
+  color: var(--primary);
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  padding: 20px;
+}
+
+.container {
+  background: rgba(255, 255, 255, 0.85);
+  border-radius: 18px;
+  padding: 24px;
+  box-shadow: 0 4px 20px rgba(0, 0, 0, 0.1);
+  max-width: 420px;
+  width: 100%;
+}
+
+h1 {
+  margin-top: 0;
+  text-align: center;
+}
+
+.field {
+  display: flex;
+  flex-direction: column;
+  margin-bottom: 16px;
+}
+
+label {
+  font-weight: 600;
+  margin-bottom: 6px;
+}
+
+input[type="text"] {
+  padding: 10px 12px;
+  border: 1px solid #d4c4b4;
+  border-radius: 8px;
+  font-size: 1rem;
+}
+
+input[type="text"]:focus {
+  outline: 2px solid var(--accent);
+}
+
+button[type="submit"] {
+  width: 100%;
+  padding: 12px;
+  background-color: var(--primary);
+  color: #fff;
+  border: none;
+  border-radius: 8px;
+  font-size: 1rem;
+  cursor: pointer;
+  transition: background-color 0.2s ease;
+}
+
+button[type="submit"]:hover {
+  background-color: #7c5742;
+}
+
+.error {
+  min-height: 1em;
+  margin: 6px 0 0;
+  color: var(--error);
+  font-size: 0.9rem;
+}
+
+.result {
+  margin-top: 20px;
+  padding: 16px;
+  background-color: var(--accent);
+  border-radius: 8px;
+  word-break: break-all;
+  font-family: 'SFMono-Regular', Consolas, 'Liberation Mono', Menlo, monospace;
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "hello-github-pages",
+  "version": "1.0.0",
+  "description": "Validation form and tests",
+  "type": "module",
+  "scripts": {
+    "test": "node --test"
+  }
+}

--- a/tests/validation.test.js
+++ b/tests/validation.test.js
@@ -1,0 +1,79 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { validateName, validateNum, validateDate, validateForm } from '../docs/scripts/validation.js';
+
+test('validateName accepts Japanese characters', () => {
+  const result = validateName('山田太郎');
+  assert.equal(result.valid, true);
+  assert.equal(result.value, '山田太郎');
+});
+
+test('validateName rejects empty value', () => {
+  const result = validateName('   ');
+  assert.equal(result.valid, false);
+  assert.match(result.error, /名前/);
+});
+
+test('validateName rejects unsupported characters', () => {
+  const result = validateName('John😀');
+  assert.equal(result.valid, false);
+  assert.match(result.error, /日本語/);
+});
+
+test('validateNum accepts positive integers', () => {
+  const result = validateNum('42');
+  assert.equal(result.valid, true);
+  assert.equal(result.value, 42);
+});
+
+test('validateNum accepts negative integers', () => {
+  const result = validateNum('-10');
+  assert.equal(result.valid, true);
+  assert.equal(result.value, -10);
+});
+
+test('validateNum rejects decimals', () => {
+  const result = validateNum('3.14');
+  assert.equal(result.valid, false);
+  assert.match(result.error, /整数/);
+});
+
+test('validateNum rejects overly large numbers', () => {
+  const result = validateNum(String(Number.MAX_SAFE_INTEGER + 1));
+  assert.equal(result.valid, false);
+  assert.match(result.error, /安全な範囲/);
+});
+
+test('validateDate accepts valid ISO dates', () => {
+  const result = validateDate('2024-02-29');
+  assert.equal(result.valid, true);
+  assert.equal(result.value, '2024-02-29');
+});
+
+test('validateDate rejects invalid format', () => {
+  const result = validateDate('2024/01/01');
+  assert.equal(result.valid, false);
+  assert.match(result.error, /YYYY-MM-DD/);
+});
+
+test('validateDate rejects nonexistent dates', () => {
+  const result = validateDate('2024-02-30');
+  assert.equal(result.valid, false);
+  assert.match(result.error, /存在する日付/);
+});
+
+test('validateForm aggregates field results', () => {
+  const result = validateForm({ name: '鈴木花子', num: '100', date: '2024-05-01' });
+  assert.equal(result.valid, true);
+  assert.equal(result.results.name.value, '鈴木花子');
+  assert.equal(result.results.num.value, 100);
+  assert.equal(result.results.date.value, '2024-05-01');
+});
+
+test('validateForm reports errors', () => {
+  const result = validateForm({ name: '', num: 'abc', date: '2024-13-01' });
+  assert.equal(result.valid, false);
+  assert.equal(result.results.name.valid, false);
+  assert.equal(result.results.num.valid, false);
+  assert.equal(result.results.date.valid, false);
+});


### PR DESCRIPTION
## Summary
- add a new form page with name, integer, and date inputs that display JSON output
- implement shared validation utilities and client-side wiring
- configure npm tests for validation logic

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68de9fc2a0108320b4c80acd8ff3a211