### PR TITLE
CI修正: Rollup Linux optional dependency を補完

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -31,6 +31,10 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      # Workaround for npm optional dependency resolution bug on CI.
+      - name: Ensure Rollup Linux binary is present
+        run: npm i --no-save @rollup/rollup-linux-x64-gnu
+
       - name: Build
         run: npm run build
 


### PR DESCRIPTION
## 概要
- GitHub Actions の build ジョブで `npm ci` 後に `@rollup/rollup-linux-x64-gnu` を明示インストール
- npm optional dependencies の解決不具合により Rollup バイナリが欠落するケースを回避

## 変更ファイル
- `.github/workflows/deploy.yml`

## 背景
- CI で `Cannot find module @rollup/rollup-linux-x64-gnu` が発生して build が失敗していたため